### PR TITLE
fix: Fix issue occurring when using a tool with list with type

### DIFF
--- a/src/toolbox_langchain/utils.py
+++ b/src/toolbox_langchain/utils.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import json
-from typing import Any, Callable, Optional, Type, cast
+from typing import Any, Callable, Optional, Type, Union, cast
 from warnings import warn
 
 from aiohttp import ClientSession
@@ -131,7 +131,7 @@ def _parse_type(type_: str) -> Any:
     elif type_ == "boolean":
         return bool
     elif type_ == "array":
-        return list
+        return list[Union[str, int, float, bool]]
     else:
         raise ValueError(f"Unsupported schema type: {type_}")
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -171,7 +171,7 @@ class TestUtils:
             ("integer", int),
             ("float", float),
             ("boolean", bool),
-            ("array", list),
+            ("array", list[Union[str, int, float, bool]]),
         ],
     )
     def test_parse_type(self, type_string, expected_type):


### PR DESCRIPTION
Temporarily relaxes type checking in the toolbox manifest handling. Currently, the toolbox manifest does not include `items` information (along with the `type` field) in the `parameters` field of the manifest. This change allows lists containing any type of value (except nested lists) as a workaround. This will be reverted once the toolbox manifest provides type information.

> [!NOTE]
> This is a temporary fix. It allows tools relying on the manifest to function until the toolbox's manifest includes type information.