### PR TITLE
chore: update rendering of tip alert in DEVELOPER.md

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -17,7 +17,8 @@ Below are the details to set up a development environment and run tests.
     pip install -e .
     ```
 1. Make code changes and contribute to the SDK's development.
-> [!TIP] Using `-e` option allows you to make changes to the SDK code and have
+> [!TIP]
+> Using `-e` option allows you to make changes to the SDK code and have
 > those changes reflected immediately without reinstalling the package.
 
 ## Test


### PR DESCRIPTION
[GitHub markdown alerts](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts) require the alert type to be on their own line for the alert to properly render.

Fixing broken rendering:
![image](https://github.com/user-attachments/assets/f7a3493b-031a-47be-941c-e65c58b4c94f)
