### PR TITLE
chore: Add additional presubmit checks in sync-repo-settings.

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -31,6 +31,10 @@ branchProtectionRules:
       - "header-check"
     # - Add required status checks like presubmit tests
       - "langchain-python-sdk-pr-py313 (toolbox-testing-438616)"
+      - "langchain-python-sdk-pr-py312 (toolbox-testing-438616)"
+      - "langchain-python-sdk-pr-py311 (toolbox-testing-438616)"
+      - "langchain-python-sdk-pr-py310 (toolbox-testing-438616)"
+      - "langchain-python-sdk-pr-py39 (toolbox-testing-438616)"
     requiredApprovingReviewCount: 1
     requiresCodeOwnerReviews: true
     requiresStrictStatusChecks: true


### PR DESCRIPTION
This is to match with what the current set of enabled presubmit checks are in this repo. Currently we do not have the sync settings bot enabled in this repo, so we are manually setting this up in the repo settings through Github UI.