### PR TITLE
doc: Update README installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ applications, enabling advanced orchestration and interaction with GenAI models.
 ## Table of Contents
 <!-- TOC -->
 
-- [Quickstart](#quickstart)
 - [Installation](#installation)
+- [Quickstart](#quickstart)
 - [Usage](#usage)
 - [Loading Tools](#loading-tools)
     - [Load a toolset](#load-a-toolset)
@@ -33,6 +33,14 @@ applications, enabling advanced orchestration and interaction with GenAI models.
 - [Asynchronous Usage](#asynchronous-usage)
 
 <!-- /TOC -->
+
+## Installation
+
+Install using `pip`:
+
+```bash
+pip install toolbox-langchain
+```
 
 ## Quickstart
 
@@ -58,18 +66,6 @@ for s in agent.stream({"messages": [("user", prompt)]}, stream_mode="values"):
         print(message)
     else:
         message.pretty_print()
-```
-
-## Installation
-
-> [!IMPORTANT]
-> This SDK is not yet available on PyPI. For now, install it from source by
-> following these [installation instructions](DEVELOPER.md).
-
-You can install the Toolbox SDK for LangChain using `pip`.
-
-```bash
-pip install toolbox-langchain
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -36,8 +36,6 @@ applications, enabling advanced orchestration and interaction with GenAI models.
 
 ## Installation
 
-Install using `pip`:
-
 ```bash
 pip install toolbox-langchain
 ```


### PR DESCRIPTION
Remove the temporary instructions of installing the package locally now that the SDK is available as a PyPI package.

Also move the installation instructions before the quickstart sections since installation is required before quickstart code can work.