### PR TITLE
fix: add items to parameter schema

### DIFF
--- a/src/toolbox_langchain/utils.py
+++ b/src/toolbox_langchain/utils.py
@@ -21,7 +21,7 @@ from deprecated import deprecated
 from pydantic import BaseModel, Field, create_model
 
 
-class BaseParameterSchema(BaseModel):
+class ParameterSchema(BaseModel):
     """
     Schema for a tool parameter.
     """
@@ -30,14 +30,7 @@ class BaseParameterSchema(BaseModel):
     type: str
     description: str
     authSources: Optional[list[str]] = None
-
-
-class ParameterSchema(BaseParameterSchema):
-    """
-    Schema for a tool parameter with items.
-    """
-
-    items: Optional[BaseParameterSchema] = None
+    items: Optional["ParameterSchema"] = None
 
 
 class ToolSchema(BaseModel):
@@ -116,7 +109,7 @@ def _schema_to_model(model_name: str, schema: list[ParameterSchema]) -> Type[Bas
     return create_model(model_name, **field_definitions)
 
 
-def _parse_type(schema_: Union[ParameterSchema, BaseParameterSchema]) -> Any:
+def _parse_type(schema_: ParameterSchema) -> Any:
     """
     Converts a schema type to a JSON type.
 

--- a/src/toolbox_langchain/utils.py
+++ b/src/toolbox_langchain/utils.py
@@ -21,7 +21,7 @@ from deprecated import deprecated
 from pydantic import BaseModel, Field, create_model
 
 
-class ParameterSchema(BaseModel):
+class BaseParameterSchema(BaseModel):
     """
     Schema for a tool parameter.
     """
@@ -30,6 +30,14 @@ class ParameterSchema(BaseModel):
     type: str
     description: str
     authSources: Optional[list[str]] = None
+
+
+class ParameterSchema(BaseParameterSchema):
+    """
+    Schema for a tool parameter with items.
+    """
+
+    items: Optional[BaseParameterSchema] = None
 
 
 class ToolSchema(BaseModel):
@@ -100,7 +108,7 @@ def _schema_to_model(model_name: str, schema: list[ParameterSchema]) -> Type[Bas
             (
                 # TODO: Remove the hardcoded optional types once optional fields
                 # are supported by Toolbox.
-                Optional[_parse_type(field.type)],
+                Optional[_parse_type(field)],
                 Field(description=field.description),
             ),
         )
@@ -108,12 +116,12 @@ def _schema_to_model(model_name: str, schema: list[ParameterSchema]) -> Type[Bas
     return create_model(model_name, **field_definitions)
 
 
-def _parse_type(type_: str) -> Any:
+def _parse_type(schema_: Union[ParameterSchema, BaseParameterSchema]) -> Any:
     """
     Converts a schema type to a JSON type.
 
     Args:
-        type_: The type name to convert.
+        schema_: The ParameterSchema to convert.
 
     Returns:
         A valid JSON type.
@@ -121,6 +129,7 @@ def _parse_type(type_: str) -> Any:
     Raises:
         ValueError: If the given type is not supported.
     """
+    type_ = schema_.type
 
     if type_ == "string":
         return str
@@ -131,7 +140,10 @@ def _parse_type(type_: str) -> Any:
     elif type_ == "boolean":
         return bool
     elif type_ == "array":
-        return list[Union[str, int, float, bool]]
+        if isinstance(schema_, ParameterSchema) and schema_.items:
+            return list[_parse_type(schema_.items)]  # type: ignore
+        else:
+            raise ValueError(f"Schema missing field items")
     else:
         raise ValueError(f"Unsupported schema type: {type_}")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Contains pytest fixtures that are accessible from all 
+"""Contains pytest fixtures that are accessible from all
 files present in the same directory."""
 
 from __future__ import annotations

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -24,7 +24,6 @@ import pytest
 from pydantic import BaseModel
 
 from toolbox_langchain.utils import (
-    BaseParameterSchema,
     ParameterSchema,
     _convert_none_to_empty_string,
     _get_auth_headers,
@@ -177,7 +176,7 @@ class TestUtils:
                     name="foo",
                     description="bar",
                     type="array",
-                    items=BaseParameterSchema(
+                    items=ParameterSchema(
                         name="foo", description="bar", type="integer"
                     ),
                 ),
@@ -197,7 +196,7 @@ class TestUtils:
                     name="foo",
                     description="bar",
                     type="array",
-                    items=BaseParameterSchema(
+                    items=ParameterSchema(
                         name="foo", description="bar", type="invalid"
                     ),
                 )


### PR DESCRIPTION
Fix issue with array parameter type throwing an error `generic::invalid_argument: Unable to submit request because search_airports functionDeclaration parameters.airlines schema didn't specify the schema type field.`

This PR does the following:
* Parse items from manifest to `ParameterSchema`.
* Convert item typing to specific type instead of using `Union`.