### PR TITLE
feat: Add support for checking tool-level auth before tool invocation.

### DIFF
--- a/src/toolbox_langchain/utils.py
+++ b/src/toolbox_langchain/utils.py
@@ -40,6 +40,7 @@ class ToolSchema(BaseModel):
 
     description: str
     parameters: list[ParameterSchema]
+    authRequired: list[str] = []
 
 
 class ManifestSchema(BaseModel):


### PR DESCRIPTION
This is to prevent tool invocation if the required tool-level auth is missing. This is similar to how we prevent tool invocation if a parameter-level auth is missing.