### PR TITLE
chore: Update GHA workflow permissions for Cloud Build Reporter

### DIFF
--- a/.github/workflows/schedule_reporter.yml
+++ b/.github/workflows/schedule_reporter.yml
@@ -20,6 +20,10 @@ on:
 
 jobs:
   run_reporter:
+    permissions:
+        issues: 'write'
+        checks: 'read'
+        contents: 'read'
     uses: ./.github/workflows/cloud_build_failure_reporter.yml
     with:
       trigger_names: "langchain-python-sdk-test-nightly,langchain-python-sdk-test-on-merge"


### PR DESCRIPTION
Similar to https://github.com/googleapis/genai-toolbox-llamaindex-python/pull/32