### PR TITLE
chore: use multiScm for Kokoro release builds

### DIFF
--- a/.github/release-trigger.yml
+++ b/.github/release-trigger.yml
@@ -13,3 +13,4 @@
 # limitations under the License.
 
 enabled: true
+multiScmName: genai-toolbox-langchain-python


### PR DESCRIPTION
As per the [Kokoro release script migration](https://docs.google.com/document/d/1P0Z5FXWd9BbyeYDUbWzYb6rbGppmvGSbM8p8YBFW-Mo/edit?tab=t.0#heading=h.2ivc9rkl4kzo), we now use multi_scm for releases.