### PR TITLE
feat(toolbox-core): add support for bound parameters

### DIFF
--- a/packages/toolbox-core/src/toolbox_core/client.py
+++ b/packages/toolbox-core/src/toolbox_core/client.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import re
 import types
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Mapping, Optional, Union
 
 from aiohttp import ClientSession
 
@@ -59,7 +59,7 @@ class ToolboxClient:
         name: str,
         schema: ToolSchema,
         auth_token_getters: dict[str, Callable[[], str]],
-        all_bound_params: dict[str, Callable[[], str]],
+        all_bound_params: Mapping[str, Union[Callable[[], Any], Any]],
     ) -> ToolboxTool:
         """Internal helper to create a callable tool from its schema."""
         # sort into reg, authn, and bound params
@@ -129,7 +129,7 @@ class ToolboxClient:
         self,
         name: str,
         auth_token_getters: dict[str, Callable[[], str]] = {},
-        bound_params: dict[str, Callable[[], str]] = {},
+        bound_params: Mapping[str, Union[Callable[[], Any], Any]] = {},
     ) -> ToolboxTool:
         """
         Asynchronously loads a tool from the server.
@@ -142,6 +142,10 @@ class ToolboxClient:
             name: The unique name or identifier of the tool to load.
             auth_token_getters: A mapping of authentication service names to
                 callables that return the corresponding authentication token.
+            bound_params: A mapping of parameter names to bind to specific values or
+                callables that are called to produce values as needed.
+
+
 
         Returns:
             ToolboxTool: A callable object representing the loaded tool, ready
@@ -170,7 +174,7 @@ class ToolboxClient:
         self,
         name: str,
         auth_token_getters: dict[str, Callable[[], str]] = {},
-        bound_params: dict[str, Callable[[], str]] = {},
+        bound_params: Mapping[str, Union[Callable[[], Any], Any]] = {},
     ) -> list[ToolboxTool]:
         """
         Asynchronously fetches a toolset and loads all tools defined within it.
@@ -179,6 +183,8 @@ class ToolboxClient:
             name: Name of the toolset to load tools.
             auth_token_getters: A mapping of authentication service names to
                 callables that return the corresponding authentication token.
+            bound_params: A mapping of parameter names to bind to specific values or
+                callables that are called to produce values as needed.
 
 
 

--- a/packages/toolbox-core/src/toolbox_core/tool.py
+++ b/packages/toolbox-core/src/toolbox_core/tool.py
@@ -262,9 +262,12 @@ class ToolboxTool:
             if p.name not in bound_params:
                 new_params.append(p)
 
+        all_bound_params = dict(self.__bound_parameters)
+        all_bound_params.update(bound_params)
+
         return self.__copy(
             params=new_params,
-            bound_params=bound_params,
+            bound_params=types.MappingProxyType(all_bound_params),
         )
 
 


### PR DESCRIPTION
Adds basic support for "bound parameters", which is a client-side only feature that allow you to bind the value of a parameter to a value (or function that produces a value). 

Makes the following changes:
* ToollboxClient: `load_tool` and `load_toolset` now have an optional parameter `bound_params`
* ToolboxTool: adds `bind_parameters` method 