### PR TITLE
docs: update syntax error on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ bound_tools = [tool.bind_param("param", "value") for tool in tools]
 ### Binding Parameters While Loading
 
 ```py
-bound_tool = toolbox.load_tool(bound_params={"param": "value"})
+bound_tool = toolbox.load_tool("my-tool", bound_params={"param": "value"})
 
 bound_tools = toolbox.load_toolset(bound_params={"param": "value"})
 ```


### PR DESCRIPTION
tool name is required in `load_tool` function.