### PR TITLE
chore: change config component

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,6 @@
     "bump-minor-pre-major": true,
     "bump-patch-for-minor-pre-major": true,
     "separate-pull-requests": true,
-    "include-component-in-tag": true,
     "changelog-sections": [
       { "type": "feat", "section": "Features" },
       { "type": "fix", "section": "Bug Fixes" },
@@ -12,11 +11,13 @@
     ],
     "packages": {
       "packages/toolbox-core": {
+        "component": "toolbox-core",
         "extra-files": [
           "src/toolbox_core/version.py"
         ]
       },
       "packages/toolbox-langchain": {
+        "component": "toolbox-langchain",
         "extra-files": [
           "src/toolbox_langchain/version.py"
         ]


### PR DESCRIPTION
Creates better looking release PRs. The components are mentioned as a part of the release PR.

`include-component-in-tag` is true by default, so we can omit the config.