### PR TITLE
chore: change back version to allow releases

### DIFF
--- a/packages/toolbox-core/src/toolbox_core/version.py
+++ b/packages/toolbox-core/src/toolbox_core/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.1.0"
+__version__ = "0.0.1"


### PR DESCRIPTION
We want to create a 0.1.0 release for toolbox-core.

We need to have the current version as less than 0.1.0, so that the new version can be 0.1.0