### PR TITLE
fix: correct tagging of releases

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
     "release-type": "python",
     "bump-minor-pre-major": true,
     "bump-patch-for-minor-pre-major": true,
+    "include-component-in-tag": true,
     "changelog-sections": [
       { "type": "feat", "section": "Features" },
       { "type": "fix", "section": "Bug Fixes" },

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,7 @@
     "release-type": "python",
     "bump-minor-pre-major": true,
     "bump-patch-for-minor-pre-major": true,
-    "include-component-in-tag": true,
+    "include-v-in-tag": true,
     "changelog-sections": [
       { "type": "feat", "section": "Features" },
       { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
Currently, our release tag looks like: `toolbox-core: v0.1.0`.

`Release-please` searches for previously tagged releases and creates new releases following that. Currently, it was searching for `toolbox-core: 0.1.0`, and thus unable to fetch the previous releases. Here, we include a `v` in the release tag search.

Note: I have updated the release tag for `toolbox-langchain` to `toolbox-langchain: v0.1.0` from `v0.1.0`.

