### PR TITLE
chore: use manifest file to create releases

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 handleGHRelease: true
-releaseType: python
+manifest: true


### PR DESCRIPTION
The release please automated releases look like [this](https://github.com/googleapis/genai-toolbox-langchain-python/pull/151) because they're not using [Manifest Driven Release](https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md).

Adding this to the release file allows `release-please` to read the existing [manifest](https://github.com/googleapis/genai-toolbox-langchain-python/blob/main/.release-please-manifest.json) and [config](https://github.com/googleapis/genai-toolbox-langchain-python/blob/main/release-please-config.json) files and create releases accordingly.